### PR TITLE
pass the message,causedBy to the super constructor for PersistenceError

### DIFF
--- a/modules/mongo-utils/src/main/scala/com/wordnik/mongo/connection/MongoDBConnectionManager.scala
+++ b/modules/mongo-utils/src/main/scala/com/wordnik/mongo/connection/MongoDBConnectionManager.scala
@@ -24,7 +24,7 @@ object MongoDBConnectionManager {
     LOGGER.finest("getting from, key: " + schemaName + ", schemaType: " + schemaType)
 
     val snl = schemaName.toLowerCase
-    if (!pool.contains(snl)) throw new PersistenceException("no configurations found for " + schemaName)
+    if (!pool.contains(snl)) throw PersistenceException("no configurations found for " + schemaName)
 
     val servers = pool(snl)
     var output: Option[DB] = None
@@ -71,7 +71,7 @@ object MongoDBConnectionManager {
 
     output match {
       case Some(db) => db
-      case _ => throw new PersistenceException("no configurations found for " + schemaName)
+      case _ => throw PersistenceException("no configurations found for " + schemaName)
     }
   }
 
@@ -144,7 +144,7 @@ object MongoDBConnectionManager {
     } catch {
       case e: Exception => {
         LOGGER.severe("can't get connection to " + host + ":" + port + "/" + schema + " with username " + username + ", password " + password);
-        throw new PersistenceException(e);
+        throw PersistenceException("can't get connection to " + host + ":" + port + "/" + schema + " with username " + username + ", password " + password, e);
       }
     }
   }
@@ -179,7 +179,7 @@ object MongoDBConnectionManager {
         Member.UNKNOWN
       }
       case _: Throwable =>
-        throw new PersistenceException("Failed to detect replication type")
+        throw PersistenceException("Failed to detect replication type")
     }
   }
 

--- a/modules/mongo-utils/src/main/scala/com/wordnik/mongo/connection/PersistenceException.scala
+++ b/modules/mongo-utils/src/main/scala/com/wordnik/mongo/connection/PersistenceException.scala
@@ -1,7 +1,7 @@
 package com.wordnik.mongo.connection
 
-class PersistenceException(msg: String, e: Exception) extends Exception {
-  def this() = this(null, null)
-  def this(msg: String) = this(msg, null)
-  def this(e: Exception) = this(null, e)
+case class PersistenceException(message: String, causedBy: Exception) extends Exception(message, causedBy)
+
+object PersistenceException {
+  def apply(msg: String): PersistenceException = PersistenceException(msg, null)
 }


### PR DESCRIPTION
since we don't currently pass the message / causedBy up to the super constructor, when this exception is printed it always just comes out as "PersistenceException null", if we pass the message upstream, we get a more meaningful error message.
